### PR TITLE
Add content methods

### DIFF
--- a/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
+++ b/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
@@ -5,7 +5,8 @@ import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3.httpclient.fs2.HttpClientFs2Backend
 import uk.gov.nationalarchives.dp.client.EntityClient._
 import uk.gov.nationalarchives.dp.client.AdminClient._
-import uk.gov.nationalarchives.dp.client.{AdminClient, EntityClient}
+import uk.gov.nationalarchives.dp.client.ContentClient.createContentClient
+import uk.gov.nationalarchives.dp.client.{AdminClient, ContentClient, EntityClient}
 
 import scala.concurrent.duration._
 
@@ -21,5 +22,10 @@ object Fs2Client {
   def adminClient(url: String, duration: FiniteDuration = 15.minutes): IO[AdminClient[IO]] =
     HttpClientFs2Backend.resource[IO]().use { backend =>
       cats.effect.IO(createAdminClient(url, backend, duration))
+    }
+
+  def contentClient(url: String, duration: FiniteDuration = 15.minutes): IO[ContentClient[IO]] =
+    HttpClientFs2Backend.resource[IO]().use { backend =>
+      cats.effect.IO(createContentClient(url, backend, duration))
     }
 }

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ContentClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ContentClientTest.scala
@@ -1,0 +1,13 @@
+package uk.gov.nationalarchives.dp.client.fs2
+
+import cats.effect.IO
+import cats.effect.IO.{asyncForIO, cont}
+import cats.effect.unsafe.implicits.global
+import uk.gov.nationalarchives.dp.client.fs2.Fs2Client._
+import uk.gov.nationalarchives.dp.client.{ContentClient, ContentClientTest}
+
+class Fs2ContentClientTest extends ContentClientTest[IO](9006) {
+  override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
+
+  override def createClient(url: String): IO[ContentClient[IO]] = contentClient(url)
+}

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/ContentClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/ContentClient.scala
@@ -1,0 +1,115 @@
+package uk.gov.nationalarchives.dp.client
+
+import cats.MonadError
+import cats.implicits._
+import cats.effect.Sync
+import sttp.client3._
+import sttp.client3.upicklejson.asJson
+import uk.gov.nationalarchives.dp.client.DataProcessor.ClosureResultIndexNames
+import uk.gov.nationalarchives.dp.client.Utils.AuthDetails
+import upickle.default._
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+import scala.concurrent.duration.FiniteDuration
+
+trait ContentClient[F[_]] {
+  def findExpiredClosedDocuments(authDetails: AuthDetails): F[List[Entity]]
+}
+object ContentClient {
+  case class SearchField(name: String, values: List[String])
+  case class SearchQuery(q: String, fields: List[SearchField])
+
+  def createContentClient[F[_], S](
+      apiBaseUrl: String,
+      backend: SttpBackend[F, S],
+      duration: FiniteDuration
+  )(implicit
+      me: MonadError[F, Throwable],
+      sync: Sync[F]
+  ): ContentClient[F] = new ContentClient[F] {
+
+    case class SearchResponseValue(objectIds: List[String], totalHits: Int)
+
+    case class SearchResponse(success: Boolean, value: SearchResponseValue)
+
+    val utils: Utils[F, S] = Utils(apiBaseUrl, backend, duration)
+    implicit val fieldWriter: Writer[SearchField] = macroW[SearchField]
+    implicit val queryWriter: Writer[SearchQuery] = macroW[SearchQuery]
+    implicit val searchResponseValueWriter: Reader[SearchResponseValue] = macroR[SearchResponseValue]
+    implicit val searchResponseWriter: Reader[SearchResponse] = macroR[SearchResponse]
+
+    import utils._
+
+    def toEntities(objectIds: List[String]): F[List[Entity]] = objectIds
+      .map(id => {
+        val pipeSplit = id.split("\\|")
+        val refType = pipeSplit.head.split(":").last
+        val entityId = UUID.fromString(pipeSplit.last)
+        Entity.fromType[F](refType, entityId, "", deleted = false)
+      })
+      .sequence
+
+    private def getClosureResultIndexNames(token: String): F[ClosureResultIndexNames] = {
+      val definitionName = "closure-result-index-definition"
+      val queryParams = Map("name" -> definitionName, "type" -> "CustomIndexDefinition")
+      val apiUri = uri"$apiBaseUrl/api/admin/documents?$queryParams"
+      for {
+        documents <- getApiResponseXml(apiUri.toString(), token)
+        apiId <- me.fromOption(
+          dataProcessor.existingApiId(documents, "Document", definitionName),
+          PreservicaClientException(s"Cannot find index definition $definitionName")
+        )
+        definitionContent <- getApiResponseXml(s"$apiBaseUrl/api/admin/documents/$apiId/content", token)
+        indexNames <- dataProcessor.closureResultIndexNames(definitionContent)
+      } yield indexNames
+    }
+
+    private def search(
+        start: Int,
+        token: String,
+        indexNames: ClosureResultIndexNames,
+        ids: List[String]
+    ): F[List[Entity]] = {
+      val max = 100
+      basicRequest
+        .get(searchUrl(start, max, indexNames))
+        .headers(Map("Preservica-Access-Token" -> token))
+        .response(asJson[SearchResponse])
+        .send(backend)
+        .flatMap(res => me.fromEither(res.body))
+        .flatMap(searchResponse =>
+          if (searchResponse.value.objectIds.isEmpty) {
+            toEntities(ids)
+          } else {
+            search(start + max, token, indexNames, searchResponse.value.objectIds ++ ids)
+          }
+        )
+    }
+
+    private def searchUrl(start: Int, max: Int, indexNames: ClosureResultIndexNames) = {
+      val documentStatusField = SearchField(indexNames.documentStatusName, "Closed" :: Nil)
+      val toDateTime = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+      val reviewDateField =
+        SearchField(indexNames.reviewDateName, s"[2000-01-01T00:00:00.000Z TO $toDateTime]" :: Nil)
+      val searchQuery = SearchQuery("", List(documentStatusField, reviewDateField))
+      val queryString = write(searchQuery)
+      val queryParams = Map(
+        "q" -> queryString,
+        "start" -> start.toString,
+        "max" -> max.toString,
+        "metadata" -> indexNames.documentStatusName
+      )
+      uri"$apiBaseUrl/api/content/search?$queryParams"
+    }
+
+    override def findExpiredClosedDocuments(authDetails: AuthDetails): F[List[Entity]] = {
+      for {
+        token <- getAuthenticationToken(authDetails)
+        indexNames <- getClosureResultIndexNames(token)
+        res <- search(0, token, indexNames, Nil)
+      } yield res
+    }
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/ContentClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/ContentClientTest.scala
@@ -1,0 +1,173 @@
+package uk.gov.nationalarchives.dp.client
+
+import cats.MonadError
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.admin.model.ServeEventQuery
+import com.github.tomakehurst.wiremock.client.MappingBuilder
+import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import com.github.tomakehurst.wiremock.client.WireMock._
+import org.scalatest.matchers.should.Matchers._
+import uk.gov.nationalarchives.dp.client.ContentClient.{SearchField, SearchQuery}
+import uk.gov.nationalarchives.dp.client.Utils.AuthDetails
+import upickle.default
+import upickle.default._
+
+import scala.jdk.CollectionConverters._
+
+abstract class ContentClientTest[F[_]](port: Int)(implicit
+    cme: MonadError[F, Throwable]
+) extends AnyFlatSpec
+    with BeforeAndAfterEach {
+  def valueFromF[T](value: F[T]): T
+
+  def createClient(url: String): F[ContentClient[F]]
+
+  val preservicaServer = new WireMockServer(port)
+
+  override def beforeEach(): Unit = {
+    preservicaServer.resetAll()
+    preservicaServer.start()
+  }
+
+  override def afterEach(): Unit = {
+    preservicaServer.stop()
+  }
+
+  val client: ContentClient[F] = valueFromF(createClient(s"http://localhost:$port"))
+
+  val tokenResponse: String = """{"token": "abcde"}"""
+  val tokenUrl = "/api/accesstoken/login"
+
+  "findExpiredClosedDocuments" should "search using the index names from the API" in {
+    val documentResponse = <DocumentsResponse xmlns="http://preservica.com/AdminAPI/v6.5">
+      <Documents>
+        <Document>
+          <Name>closure-result-index-definition</Name>
+          <ApiId>1</ApiId>
+        </Document>
+      </Documents>
+    </DocumentsResponse>
+    val documentContentResponse = <index>
+        <shortName>tns</shortName>
+        <term indexName="test_date_index" indexType="DATE"/>
+        <term indexName="test_string_index" indexType="STRING_DEFAULT"/>
+      </index>
+    preservicaServer.stubFor(post(urlPathMatching(tokenUrl)).willReturn(ok(tokenResponse)))
+    preservicaServer.stubFor(get(urlPathMatching("/api/admin/documents")).willReturn(okXml(documentResponse.toString)))
+    preservicaServer.stubFor(
+      get(urlEqualTo("/api/admin/documents/1/content"))
+        .willReturn(okXml(documentContentResponse.toString))
+    )
+    val searchResponse = """{"success":true,"value":{"objectIds":[],"totalHits":1}}"""
+    val searchMapping: MappingBuilder = get(urlPathMatching("/api/content/search"))
+      .willReturn(okJson(searchResponse))
+    preservicaServer.stubFor(searchMapping)
+
+    valueFromF(client.findExpiredClosedDocuments(AuthDetails("", "")))
+
+    val events =
+      preservicaServer.getServeEvents(ServeEventQuery.forStubMapping(searchMapping.build())).getServeEvents.asScala
+    val searchQParam = events.head.getRequest.getQueryParams.get("q").values().get(0)
+    implicit val searchFieldReader: default.Reader[SearchField] = macroR[SearchField]
+    implicit val searchQueryReader: default.Reader[SearchQuery] = macroR[SearchQuery]
+    val query = read[SearchQuery](searchQParam)
+    val fieldNames = query.fields.map(_.name).sorted
+    fieldNames.head should equal("tns.test_date_index")
+    fieldNames.last should equal("tns.test_string_index")
+  }
+
+  "findExpiredClosedDocuments" should "return an error if the search index is not found" in {
+    val documentResponse = <DocumentsResponse xmlns="http://preservica.com/AdminAPI/v6.5">
+      <Documents>
+        <Document>
+          <Name>another-result-index-definition</Name>
+          <ApiId>1</ApiId>
+        </Document>
+      </Documents>
+    </DocumentsResponse>
+    preservicaServer.stubFor(post(urlPathMatching(tokenUrl)).willReturn(ok(tokenResponse)))
+    preservicaServer.stubFor(get(urlPathMatching("/api/admin/documents")).willReturn(okXml(documentResponse.toString)))
+
+    val error = intercept[PreservicaClientException] {
+      valueFromF(client.findExpiredClosedDocuments(AuthDetails("", "")))
+    }
+    error.getMessage should equal("Cannot find index definition closure-result-index-definition")
+  }
+
+  "findExpiredClosedDocuments" should "return an error if the search index contains the wrong field types" in {
+    val documentResponse = <DocumentsResponse xmlns="http://preservica.com/AdminAPI/v6.5">
+      <Documents>
+        <Document>
+          <Name>closure-result-index-definition</Name>
+          <ApiId>1</ApiId>
+        </Document>
+      </Documents>
+    </DocumentsResponse>
+    val documentContentResponse = <index>
+      <shortName>tns</shortName>
+      <term indexName="test_date_index" indexType="ANOTHER_TYPE"/>
+      <term indexName="test_string_index" indexType="A_DIFFERENT_TYPE"/>
+    </index>
+    preservicaServer.stubFor(post(urlPathMatching(tokenUrl)).willReturn(ok(tokenResponse)))
+    preservicaServer.stubFor(get(urlPathMatching("/api/admin/documents")).willReturn(okXml(documentResponse.toString)))
+    preservicaServer.stubFor(
+      get(urlEqualTo("/api/admin/documents/1/content"))
+        .willReturn(okXml(documentContentResponse.toString))
+    )
+    val error = intercept[PreservicaClientException] {
+      valueFromF(client.findExpiredClosedDocuments(AuthDetails("", "")))
+    }
+    error.getMessage should equal("No review date index found for closure result")
+  }
+
+  "findExpiredClosedDocuments" should "call the API multiple times if there are multiple pages" in {
+    val documentResponse = <DocumentsResponse xmlns="http://preservica.com/AdminAPI/v6.5">
+      <Documents>
+        <Document>
+          <Name>closure-result-index-definition</Name>
+          <ApiId>1</ApiId>
+        </Document>
+      </Documents>
+    </DocumentsResponse>
+    val documentContentResponse = <index>
+      <shortName>tns</shortName>
+      <term indexName="test_date_index" indexType="DATE"/>
+      <term indexName="test_string_index" indexType="STRING_DEFAULT"/>
+    </index>
+    preservicaServer.stubFor(post(urlPathMatching(tokenUrl)).willReturn(ok(tokenResponse)))
+    preservicaServer.stubFor(get(urlPathMatching("/api/admin/documents")).willReturn(okXml(documentResponse.toString)))
+    preservicaServer.stubFor(
+      get(urlEqualTo("/api/admin/documents/1/content"))
+        .willReturn(okXml(documentContentResponse.toString))
+    )
+    val firstSearchResponse =
+      """{"success":true,"value":{"objectIds":["sdb:IO|4d2813fb-bb00-4c07-bfb9-374104a347c6"],"totalHits":1}}"""
+    val secondSearchResponse = """{"success":true,"value":{"objectIds":[],"totalHits":1}}"""
+    val firstSearchMapping: MappingBuilder = get(urlPathMatching("/api/content/search"))
+      .inScenario("RecursiveCall")
+      .whenScenarioStateIs(STARTED)
+      .willReturn(okJson(firstSearchResponse))
+      .willSetStateTo("Next call")
+    val secondSearchMapping: MappingBuilder = get(urlPathMatching("/api/content/search"))
+      .inScenario("RecursiveCall")
+      .whenScenarioStateIs("Next call")
+      .willReturn(okJson(secondSearchResponse))
+
+    preservicaServer.stubFor(firstSearchMapping)
+    preservicaServer.stubFor(secondSearchMapping)
+
+    valueFromF(client.findExpiredClosedDocuments(AuthDetails("", "")))
+
+    val firstEvents =
+      preservicaServer.getServeEvents(ServeEventQuery.forStubMapping(firstSearchMapping.build())).getServeEvents.asScala
+    val secondEvents = preservicaServer
+      .getServeEvents(ServeEventQuery.forStubMapping(secondSearchMapping.build()))
+      .getServeEvents
+      .asScala
+
+    firstEvents.size should equal(1)
+    secondEvents.size should equal(1)
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
@@ -226,4 +226,47 @@ abstract class DataProcessorTest[F[_]](implicit cme: MonadError[F, Throwable]) e
       deleted = true
     )
   }
+
+  "closureResultIndexNames" should "return an error if the short name is missing" in {
+    val res = <index>
+      <term indexName="test_date_index" indexType="DATE"/>
+      <term indexName="test_string_index" indexType="STRING_DEFAULT"/>
+    </index>
+    val entitiesF = new DataProcessor[F]().closureResultIndexNames(res)
+    val error = intercept[PreservicaClientException](valueFromF(entitiesF))
+    error.getMessage should equal("No short name found")
+  }
+
+  "closureResultIndexNames" should "return an error if the date index is missing" in {
+    val res = <index>
+      <shortName>test</shortName>
+      <term indexName="test_string_index" indexType="STRING_DEFAULT"/>
+    </index>
+    val entitiesF = new DataProcessor[F]().closureResultIndexNames(res)
+    val error = intercept[PreservicaClientException](valueFromF(entitiesF))
+    error.getMessage should equal("No review date index found for closure result")
+  }
+
+  "closureResultIndexNames" should "return an error if the string index is missing" in {
+    val res = <index>
+      <shortName>test</shortName>
+      <term indexName="test_string_index" indexType="DATE"/>
+    </index>
+    val entitiesF = new DataProcessor[F]().closureResultIndexNames(res)
+    val error = intercept[PreservicaClientException](valueFromF(entitiesF))
+    error.getMessage should equal("No document status index found for closure result")
+  }
+
+  "closureResultIndexNames" should "return the index names" in {
+    val res = <index>
+      <shortName>test</shortName>
+      <term indexName="test_date_index" indexType="DATE"/>
+      <term indexName="test_string_index" indexType="STRING_DEFAULT"/>
+    </index>
+    val entitiesF = new DataProcessor[F]().closureResultIndexNames(res)
+    val result = valueFromF(entitiesF)
+
+    result.documentStatusName should equal("test.test_string_index")
+    result.reviewDateName should equal("test.test_date_index")
+  }
 }

--- a/zio/src/main/scala/uk/gov/nationalarchives/dp/client/zio/ZioClient.scala
+++ b/zio/src/main/scala/uk/gov/nationalarchives/dp/client/zio/ZioClient.scala
@@ -4,7 +4,8 @@ import sttp.capabilities.zio.ZioStreams
 import sttp.client3.httpclient.zio.HttpClientZioBackend
 import uk.gov.nationalarchives.dp.client.EntityClient._
 import uk.gov.nationalarchives.dp.client.AdminClient._
-import uk.gov.nationalarchives.dp.client.{AdminClient, EntityClient}
+import uk.gov.nationalarchives.dp.client.ContentClient._
+import uk.gov.nationalarchives.dp.client.{AdminClient, ContentClient, EntityClient}
 import zio.Task
 import zio.interop.catz._
 
@@ -23,5 +24,10 @@ object ZioClient {
   def adminClient(url: String, duration: FiniteDuration = 15.minutes): Task[AdminClient[Task]] =
     HttpClientZioBackend().map { backend =>
       createAdminClient[Task, ZioStreams](url, backend, duration)
+    }
+
+  def contentClient(url: String, duration: FiniteDuration = 15.minutes): Task[ContentClient[Task]] =
+    HttpClientZioBackend().map { backend =>
+      createContentClient[Task, ZioStreams](url, backend, duration)
     }
 }

--- a/zio/src/test/scala/uk/gov/nationalarchives/dp/client/zio/ZioContentClientTest.scala
+++ b/zio/src/test/scala/uk/gov/nationalarchives/dp/client/zio/ZioContentClientTest.scala
@@ -1,0 +1,14 @@
+package uk.gov.nationalarchives.dp.client.zio
+import uk.gov.nationalarchives.dp.client.zio.ZioClient.contentClient
+import uk.gov.nationalarchives.dp.client.{ContentClient, ContentClientTest}
+import zio._
+import zio.interop.catz._
+
+class ZioContentClientTest extends ContentClientTest[Task](9005) {
+
+  override def valueFromF[T](value: Task[T]): T = Unsafe.unsafe { implicit unsafe =>
+    Runtime.default.unsafe.run(value).getOrThrow()
+  }
+
+  override def createClient(url: String): Task[ContentClient[Task]] = contentClient(url)
+}


### PR DESCRIPTION
There is just the one  public method to get any expired, closed refs.
The method will check the indexes in Preservica first to get the correct
name, to try an avoid a change in the config breaking this lambda.
