### PR TITLE
feat: Add logging for the preservica client.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     awsSecretsManager,
     catsCore,
+    log4Cats,
     scalaCacheCaffeine,
     scalaXml,
     sttpCore,

--- a/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
+++ b/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
@@ -6,8 +6,9 @@ import sttp.client3.httpclient.fs2.HttpClientFs2Backend
 import uk.gov.nationalarchives.dp.client.EntityClient._
 import uk.gov.nationalarchives.dp.client.AdminClient._
 import uk.gov.nationalarchives.dp.client.ContentClient.createContentClient
-import uk.gov.nationalarchives.dp.client.{AdminClient, ContentClient, EntityClient}
+import uk.gov.nationalarchives.dp.client.{AdminClient, ContentClient, EntityClient, LoggingWrapper}
 import uk.gov.nationalarchives.dp.client.Client.ClientConfig
+
 import scala.concurrent.duration._
 
 object Fs2Client {
@@ -19,7 +20,7 @@ object Fs2Client {
       ssmEndpointUri: String = defaultSecretsManagerEndpoint
   ): IO[EntityClient[IO, Fs2Streams[IO]]] =
     HttpClientFs2Backend.resource[IO]().use { backend =>
-      cats.effect.IO(createEntityClient(ClientConfig(url, backend, duration, ssmEndpointUri)))
+      cats.effect.IO(createEntityClient(ClientConfig(url, LoggingWrapper(backend), duration, ssmEndpointUri)))
     }
 
   def adminClient(
@@ -28,7 +29,7 @@ object Fs2Client {
       ssmEndpointUri: String = defaultSecretsManagerEndpoint
   ): IO[AdminClient[IO]] =
     HttpClientFs2Backend.resource[IO]().use { backend =>
-      cats.effect.IO(createAdminClient(ClientConfig(url, backend, duration, ssmEndpointUri)))
+      cats.effect.IO(createAdminClient(ClientConfig(url, LoggingWrapper(backend), duration, ssmEndpointUri)))
     }
 
   def contentClient(
@@ -37,6 +38,6 @@ object Fs2Client {
       ssmEndpointUri: String = defaultSecretsManagerEndpoint
   ): IO[ContentClient[IO]] =
     HttpClientFs2Backend.resource[IO]().use { backend =>
-      cats.effect.IO(createContentClient(ClientConfig(url, backend, duration, ssmEndpointUri)))
+      cats.effect.IO(createContentClient(ClientConfig(url, LoggingWrapper(backend), duration, ssmEndpointUri)))
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,7 @@ object Dependencies {
   lazy val sttpCore = "com.softwaremill.sttp.client3" %% "core" % sttpVersion
   lazy val scalaCacheCaffeine = "com.github.cb372" %% "scalacache-caffeine" % scalaCacheVersion
   lazy val sttpFs2 = "com.softwaremill.sttp.client3" %% "fs2" % sttpVersion
+  lazy val log4Cats =  "org.typelevel" %% "log4cats-slf4j"   % "2.6.0"
   lazy val sttpUpickle = "com.softwaremill.sttp.client3" %% "upickle" % sttpVersion
   lazy val sttpZio = "com.softwaremill.sttp.client3" %% "zio" % sttpVersion
   lazy val awsSecretsManager = "software.amazon.awssdk" % "secretsmanager" % "2.20.26"

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/LoggingWrapper.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/LoggingWrapper.scala
@@ -1,0 +1,34 @@
+package uk.gov.nationalarchives.dp.client
+
+import cats.MonadError
+import cats.effect.Sync
+import cats.implicits._
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import sttp.capabilities
+import sttp.client3.{DelegateSttpBackend, Request, Response, SttpBackend}
+
+class LoggingWrapper[F[_], P](delegate: SttpBackend[F, P])(implicit val me: MonadError[F, Throwable], sync: Sync[F])
+    extends DelegateSttpBackend[F, P](delegate) {
+
+  override def send[T, R >: P with capabilities.Effect[F]](request: Request[T, R]): F[Response[T]] = {
+    val method = request.method.method
+    val url = request.uri.toString
+    val ctx = Map("url" -> url, "method" -> method)
+    (for {
+      logger <- Slf4jLogger.create[F]
+      res <- delegate.send(request)
+      _ <- logger
+        .info(ctx + ("code" -> res.code.code.toString))(s"Sending $method request to $url. Response ${res.code.code}")
+    } yield res).onError(err =>
+      for {
+        logger <- Slf4jLogger.create[F]
+        _ <- logger.error(ctx, err)(s"Error sending $method request to $url ")
+      } yield ()
+    )
+  }
+}
+object LoggingWrapper {
+  def apply[F[_], P](delegate: SttpBackend[F, P])(implicit me: MonadError[F, Throwable], sync: Sync[F]) =
+    new LoggingWrapper[F, P](delegate)
+
+}

--- a/zio/src/main/scala/uk/gov/nationalarchives/dp/client/zio/ZioClient.scala
+++ b/zio/src/main/scala/uk/gov/nationalarchives/dp/client/zio/ZioClient.scala
@@ -6,7 +6,7 @@ import uk.gov.nationalarchives.dp.client.EntityClient._
 import uk.gov.nationalarchives.dp.client.AdminClient._
 import uk.gov.nationalarchives.dp.client.Client.ClientConfig
 import uk.gov.nationalarchives.dp.client.ContentClient._
-import uk.gov.nationalarchives.dp.client.{AdminClient, ContentClient, EntityClient}
+import uk.gov.nationalarchives.dp.client.{AdminClient, ContentClient, EntityClient, LoggingWrapper}
 import zio.Task
 import zio.interop.catz._
 
@@ -21,7 +21,7 @@ object ZioClient {
       ssmEndpointUri: String = defaultSecretsManagerEndpoint
   ): Task[EntityClient[Task, ZioStreams]] =
     HttpClientZioBackend().map { backend =>
-      createEntityClient[Task, ZioStreams](ClientConfig(url, backend, duration, ssmEndpointUri))
+      createEntityClient[Task, ZioStreams](ClientConfig(url, LoggingWrapper(backend), duration, ssmEndpointUri))
     }
 
   def adminClient(


### PR DESCRIPTION
This uses a custom backend to log each of the requests and the response
codes and errors. It adds the url, response code and http method as a
context map which should hopefully turn into a json object in the
calling client.
