### PR TITLE
feat: DR2-1123 Disk based caching.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     awsSecretsManager,
     catsCore,
-    scalaCacheCaffeine,
+    scalaCacheCore,
     scalaXml,
     sttpCore,
     sttpFs2,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,9 +5,9 @@ object Dependencies {
 
   lazy val catsCore = "org.typelevel" %% "cats-core" % "2.9.0"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.15"
+  lazy val scalaCacheCore = "com.github.cb372" %% "scalacache-core" % scalaCacheVersion
   lazy val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
   lazy val sttpCore = "com.softwaremill.sttp.client3" %% "core" % sttpVersion
-  lazy val scalaCacheCaffeine = "com.github.cb372" %% "scalacache-caffeine" % scalaCacheVersion
   lazy val sttpFs2 = "com.softwaremill.sttp.client3" %% "fs2" % sttpVersion
   lazy val sttpUpickle = "com.softwaremill.sttp.client3" %% "upickle" % sttpVersion
   lazy val sttpZio = "com.softwaremill.sttp.client3" %% "zio" % sttpVersion

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
@@ -3,9 +3,7 @@ package uk.gov.nationalarchives.dp.client
 import cats.MonadError
 import cats.effect.Sync
 import cats.implicits._
-import com.github.benmanes.caffeine.cache.Caffeine
 import scalacache._
-import scalacache.caffeine._
 import scalacache.memoization._
 import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.regions.Region
@@ -31,9 +29,7 @@ class Client[F[_], S](clientConfig: ClientConfig[F, S])(implicit
 
   implicit val responsePayloadRW: ReadWriter[Token] = macroRW[Token]
 
-  implicit val cache: Cache[F, String, F[String]] = CaffeineCache(
-    Caffeine.newBuilder.build[String, Entry[F[String]]]
-  )
+  implicit val cache: Cache[F, String, F[String]] = new PreservicaClientCache()
 
   val backend: SttpBackend[F, S] = clientConfig.backend
   val duration: FiniteDuration = clientConfig.duration

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/PreservicaClientCache.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/PreservicaClientCache.scala
@@ -1,0 +1,58 @@
+package uk.gov.nationalarchives.dp.client
+
+import cats.effect.Sync
+import cats.implicits._
+import scalacache.AbstractCache
+import scalacache.logging.Logger
+
+import java.io.{File, FilenameFilter}
+import java.nio.file.{Files, Path, Paths, StandardOpenOption}
+import scala.concurrent.duration.Duration
+import scala.util.Try
+
+class PreservicaClientCache[F[_]: Sync] extends AbstractCache[F, String, F[String]] {
+  implicit class PathUtils(key: String) {
+    def toPath: Path = Paths.get(s"/tmp/cache_$key")
+  }
+
+  private def getAttribute(path: Path, name: String): Long =
+    new String(Files.getAttribute(path, s"user:$name").asInstanceOf[Array[Byte]]).toLong
+  protected val F: Sync[F] = Sync[F]
+
+  override protected def logger: Logger[F] = Logger.getLogger[F](getClass.getName)
+
+  override protected def doGet(key: String): F[Option[F[String]]] = {
+    F.pure(Try(Files.readString(key.toPath)).toOption.flatMap(contents => {
+      val ttl = getAttribute(key.toPath, "ttl")
+      val entry = getAttribute(key.toPath, "entry")
+      if (System.currentTimeMillis() > (ttl + entry)) None else Option(F.pure(contents))
+    }))
+  }
+
+  override protected def doPut(key: String, value: F[String], ttl: Option[Duration]): F[Unit] = {
+    println(ttl)
+    value.map(s => {
+      Files.write(key.toPath, s.getBytes(), StandardOpenOption.CREATE)
+      val ttlMillis = ttl.map(_.toMillis).getOrElse(0)
+      Files.setAttribute(key.toPath, "user:ttl", ttlMillis.toString.getBytes)
+      Files.setAttribute(key.toPath, "user:entry", System.currentTimeMillis.toString.getBytes)
+    })
+  }
+
+  override protected def doRemove(key: String): F[Unit] = {
+    F.unit.map(_ => Files.delete(key.toPath))
+  }
+
+  override protected def doRemoveAll: F[Unit] = {
+    F.pure {
+      new File("/tmp")
+        .listFiles(new FilenameFilter {
+          override def accept(dir: File, name: String): Boolean = name.startsWith("cache_")
+        })
+        .toList
+        .foreach(f => Files.delete(f.toPath))
+    }
+  }
+
+  override def close: F[Unit] = F.unit
+}

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/AdminClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/AdminClientTest.scala
@@ -9,6 +9,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor4}
 import uk.gov.nationalarchives.dp.client.FileInfo._
+import uk.gov.nationalarchives.dp.client.TestUtils.deleteCacheFiles
 
 import scala.jdk.CollectionConverters._
 import scala.xml.{Elem, Node}
@@ -34,6 +35,7 @@ abstract class AdminClientTest[F[_]](preservicaPort: Int, secretsManagerPort: In
     preservicaServer.start()
     secretsManagerServer.start()
     secretsManagerServer.stubFor(post(urlEqualTo("/")).willReturn(okJson(secretsResponse)))
+    deleteCacheFiles()
   }
 
   override def afterEach(): Unit = {

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/ContentClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/ContentClientTest.scala
@@ -10,6 +10,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import com.github.tomakehurst.wiremock.client.WireMock._
 import org.scalatest.matchers.should.Matchers._
 import uk.gov.nationalarchives.dp.client.ContentClient.{SearchField, SearchQuery}
+import uk.gov.nationalarchives.dp.client.TestUtils.deleteCacheFiles
 import upickle.default
 import upickle.default._
 
@@ -34,6 +35,7 @@ abstract class ContentClientTest[F[_]](preservicaPort: Int, secretsManagerPort: 
     preservicaServer.start()
     secretsManagerServer.start()
     secretsManagerServer.stubFor(post(urlEqualTo("/")).willReturn(okJson(secretsResponse)))
+    deleteCacheFiles()
   }
 
   override def afterEach(): Unit = {

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -9,6 +9,8 @@ import org.scalatest.{Assertion, BeforeAndAfterEach}
 import sttp.capabilities.Streams
 import uk.gov.nationalarchives.dp.client.Entities.fromType
 import uk.gov.nationalarchives.dp.client.Client._
+import uk.gov.nationalarchives.dp.client.TestUtils.deleteCacheFiles
+
 import java.time.{ZoneId, ZonedDateTime}
 import java.util.UUID
 import scala.jdk.CollectionConverters._
@@ -33,6 +35,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     preservicaServer.resetAll()
     secretsManagerServer.start()
     secretsManagerServer.stubFor(post(urlEqualTo("/")).willReturn(okJson(secretsResponse)))
+    deleteCacheFiles()
   }
 
   override def afterEach(): Unit = {

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/TestUtils.scala
@@ -1,0 +1,13 @@
+package uk.gov.nationalarchives.dp.client
+
+import java.io.{File, FilenameFilter}
+import java.nio.file.Files
+
+object TestUtils {
+  def deleteCacheFiles(): Unit = new File("/tmp")
+    .listFiles(new FilenameFilter {
+      override def accept(dir: File, name: String): Boolean = name.startsWith("cache_")
+    })
+    .toList
+    .foreach(f => Files.delete(f.toPath))
+}


### PR DESCRIPTION
This now uses a custom class which extends ScalaCache AbstractCache

This uses the file system in the /tmp directory to store values in the
cache. Expiration times are put as attributes on the files themselves
when the item is added to the cache.

I've updated the tests as well. The disk cache persists between tests
now so I need to delete the temporary files it creates
