### PR TITLE
Make entity type optional.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/dp/client/Entities.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/Entities.scala
@@ -1,27 +1,37 @@
 package uk.gov.nationalarchives.dp.client
 
 import cats.MonadError
+import cats.implicits.catsSyntaxOptionId
 
 import java.util.UUID
 
 object Entities {
-  case class Entity(entityType: String, ref: UUID, title: Option[String], deleted: Boolean, path: String)
+  case class Entity(
+      entityType: Option[String],
+      ref: UUID,
+      title: Option[String],
+      deleted: Boolean,
+      path: Option[String]
+  )
 
   def fromType[F[_]](entityType: String, ref: UUID, title: Option[String], deleted: Boolean)(implicit
       me: MonadError[F, Throwable]
   ): F[Entity] = entityType match {
     case "IO" =>
       me.pure {
-        Entity("IO", ref, title, deleted, "information-objects")
+        Entity("IO".some, ref, title, deleted, "information-objects".some)
       }
     case "CO" =>
       me.pure {
-        Entity("CO", ref, title, deleted, "content-objects")
+        Entity("CO".some, ref, title, deleted, "content-objects".some)
       }
     case "SO" =>
       me.pure {
-        Entity("SO", ref, title, deleted, "structural-objects")
+        Entity("SO".some, ref, title, deleted, "structural-objects".some)
       }
-    case _ => me.raiseError(PreservicaClientException(s"Entity type $entityType not recognised"))
+    case _ =>
+      me.pure {
+        Entity(None, ref, title, deleted, None)
+      }
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
@@ -229,7 +229,7 @@ abstract class DataProcessorTest[F[_]](implicit cme: MonadError[F, Throwable]) e
         fileNumber: Int,
         deleted: Boolean = false
     ) = {
-      entity.path should equal(entityType)
+      entity.path.get should equal(entityType)
       entity.ref.toString should equal(uuid)
       entity.deleted should equal(deleted)
       entity.title.get should equal(s"file$fileNumber.txt")

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityTest.scala
@@ -21,15 +21,9 @@ abstract class EntityTest[F[_]](implicit cme: MonadError[F, Throwable])
   )
   forAll(entityTypes) { (entityType, expectedPath) =>
     "fromType" should s"return an object with path $expectedPath for entity type $entityType" in {
-      valueFromF(fromType(entityType, UUID.randomUUID(), None, deleted = false)).path should equal(
+      valueFromF(fromType(entityType, UUID.randomUUID(), None, deleted = false)).path.get should equal(
         expectedPath
       )
     }
-  }
-
-  "fromType" should s"return an an error for an unknown entity type" in {
-    intercept[PreservicaClientException] {
-      valueFromF(fromType("PO", UUID.randomUUID(), None, deleted = false))
-    }.getMessage should equal("Entity type PO not recognised")
   }
 }


### PR DESCRIPTION
Entities which have been soft deleted in Preservica don't have an entity
type. At the moment, the entity event generator is failing because the
type is missing and an error is being thrown.

It's now optional. If you try to pass this entity to the
metadataForEntity method, it won't work but that's fine.
